### PR TITLE
pdf-export fix by adding $revealjs-url$/

### DIFF
--- a/inst/rmarkdown/templates/revealjs_presentation/default.html
+++ b/inst/rmarkdown/templates/revealjs_presentation/default.html
@@ -101,7 +101,7 @@ $endif$
       var link = document.createElement( 'link' );
       link.rel = 'stylesheet';
       link.type = 'text/css';
-      link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
+      link.href = window.location.search.match( /print-pdf/gi ) ? '$revealjs-url$/css/print/pdf.css' : '$revealjs-url$/css/print/paper.css';
       document.getElementsByTagName( 'head' )[0].appendChild( link );
     </script>
     <!--[if lt IE 9]>


### PR DESCRIPTION
printing slides is broken without the proper path to the revealjs pdf.css and print.css