### PR TITLE
Stop ignoring minified files

### DIFF
--- a/inst/rmarkdown/templates/revealjs_presentation/.gitignore
+++ b/inst/rmarkdown/templates/revealjs_presentation/.gitignore
@@ -4,5 +4,3 @@ log/*.log
 tmp/**
 node_modules/
 .sass-cache
-css/reveal.min.css
-js/reveal.min.js


### PR DESCRIPTION
(This is related to https://github.com/jjallaire/revealjs/issues/18)

Minified JS/CSS files are ignored since they are included in `.gitignore`, which may cause problems when `self_contained: false`.

This problem is rather subtle; this matters only when we manage knitted files with git (that's why you could not reproduce #18 in local...) and we can avoid this by `git add -f`. But I think minified files should not be ignored by default.